### PR TITLE
Add cleanupEmptyNamespaces option

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -96,6 +96,11 @@ interface ServerOptions extends EngineOptions, AttachOptions {
      */
     skipMiddlewares?: boolean;
   };
+  /**
+   * whether or not to remove namespaces that have no sockets connected to them
+   * @default false
+   */
+  cleanupEmptyNamespaces;
 }
 
 /**
@@ -153,6 +158,7 @@ export class Server<
    *
    */
   public engine: BaseServer;
+  public readonly cleanupEmptyNamespaces: boolean;
 
   /** @private */
   readonly _parser: typeof parser;
@@ -226,6 +232,7 @@ export class Server<
     this.path(opts.path || "/socket.io");
     this.connectTimeout(opts.connectTimeout || 45000);
     this.serveClient(false !== opts.serveClient);
+    this.cleanupEmptyNamespaces = !!opts.cleanupEmptyNamespaces;
     this._parser = opts.parser || parser;
     this.encoder = new this._parser.Encoder();
     this.opts = opts;

--- a/lib/namespace.ts
+++ b/lib/namespace.ts
@@ -694,4 +694,23 @@ export class Namespace<
       this.adapter
     ).disconnectSockets(close);
   }
+
+  /**
+   * Cleans up the namespace if necessary (if the server option cleanupEmptyNamespace is true and there are no sockets connected to the namespace).
+   *
+   * @param nsp - this namespace to cleanup
+   *
+   */
+  cleanupNamespace() {
+    if (!this.server.cleanupEmptyNamespaces) {
+      return;
+    }
+
+    if (this.sockets.size !== 0) {
+      return;
+    }
+
+    this.adapter.close();
+    this.server._nsps.delete(this.name);
+  }
 }

--- a/lib/socket.ts
+++ b/lib/socket.ts
@@ -713,6 +713,7 @@ export class Socket<
     this.client._remove(this);
     this.connected = false;
     this.emitReserved("disconnect", reason);
+    this.nsp.cleanupNamespace();
     return;
   }
 


### PR DESCRIPTION
If the option is turned on, when a socket disconnects, it will check if the namespace the socket was connect to has any other sockets connected. If there are none, it will call adapter.close() and remove the namespace from the internal list.


### The kind of change this PR does introduce

* [ ] a bug fix
* [x] a new feature
* [ ] an update to the documentation
* [x] a code change that improves performance
* [ ] other

### Current behavior


### New behavior


### Other information (e.g. related issues)


